### PR TITLE
Use logger.error

### DIFF
--- a/main.py
+++ b/main.py
@@ -50,7 +50,6 @@ def crl():
         key = s3.Object(bucket_name, file_name)
         crl_data = key.get()['Body'].read()
     except botocore.exceptions.ClientError as error:
-        # check whether this should be logger.exception or logger.error
         logger.error(error)
         abort(500)
 


### PR DESCRIPTION
We have a choice here of using `logger.error` or `logger.exception`.
`logger.exception`uses the log level of ERROR but saves us of having
 to pass `exc_info=True` into `logger.error` to get the stack trace
 which comes automatically with `logger.exception`. I don't think we
 particularly need the full stack trace, it should hopefully be pretty
 clear what has happened.

 I don't think the decision matters too much to be honest...