### PR TITLE
Add config file for multiple environments

### DIFF
--- a/config.py
+++ b/config.py
@@ -1,0 +1,48 @@
+import botocore
+
+
+class Config(object):
+    AWS_REGION = "eu-west-2"
+    AWS_CONFIG = botocore.config.Config(region_name=AWS_REGION)
+
+
+class Staging(Config):
+    PRIVATE_CAS = {
+        "vpn": {
+            "ca_id": "fb0bf875-66a5-4447-bae3-403c457bda2d",
+            "revocation_bucket": "gds-cb-vjv982-vpn-ca-revoc",
+            "account_id": "144489291306"
+        },
+        "tls": {
+            "ca_id": "TBC",
+            "revocation_bucket": "TBC",
+            "account_id": "TBC"
+        }
+    }
+
+
+class Development(Staging):
+    # Use our staging private CAs for local development
+    pass
+
+
+class Production(Config):
+    PRIVATE_CAS = {
+        "vpn": {
+            "ca_id": "TBC",
+            "revocation_bucket": "TBC",
+            "account_id": "TBC"
+        },
+        "tls": {
+            "ca_id": "TBC",
+            "revocation_bucket": "TBC",
+            "account_id": "TBC"
+        }
+    }
+
+
+configs = {
+    'development': Development,
+    'staging': Staging,
+    'production': Production,
+}

--- a/main.py
+++ b/main.py
@@ -1,24 +1,23 @@
 import logging
+import os
 
 from flask import Flask, Response, abort, request
 from boto3 import client, resource
 import botocore
+
+from config import configs
 
 logger = logging.getLogger()
 logger.setLevel(logging.INFO)
 
 app = Flask(__name__)
 
+notify_environment = os.environ['NOTIFY_ENVIRONMENT']
+app.config.from_object(configs[notify_environment])
 
-AWS_REGION = "eu-west-2"
-AWS_CONFIG = botocore.config.Config(region_name=AWS_REGION)
-PRIVATE_CAS = {
-    "vpn": {
-        "ca_id": "fb0bf875-66a5-4447-bae3-403c457bda2d",
-        "revocation_bucket": "gds-cb-vjv982-vpn-ca-revoc",
-        "account_id": "144489291306"
-    }
-}
+AWS_REGION = app.config["AWS_REGION"]
+AWS_CONFIG = app.config["AWS_CONFIG"]
+PRIVATE_CAS = app.config["PRIVATE_CAS"]
 
 
 @app.route('/healthcheck')


### PR DESCRIPTION
Based on the notify api config files. Shows where we need to fill
variables in for TLS CAs and VPN prod CA.

TODO: Add instructions to readme about setting an environment variable for `NOTIFY_ENVIRONMENT` but this will be done when https://github.com/alphagov/notifications-certificate-management/pull/3 is merged