### PR TITLE
Add tests, and restructure the app slightly to make it easier to test

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,12 +5,12 @@ DOCKER_IMAGE = ${DOCKER_USER_NAME}/notifications-certificate-management
 DOCKER_IMAGE_TAG = latest
 DOCKER_IMAGE_NAME = ${DOCKER_IMAGE}:${DOCKER_IMAGE_TAG}
 
-NOTIFY_ENVIRONMENT ?= development 
+NOTIFY_ENVIRONMENT ?= development
 PORT ?= 8000
 
 .PHONY: test
 test:
-	flake8 .
+	./run_tests.sh
 
 .PHONY: build-docker-image
 build-docker-image:

--- a/config.py
+++ b/config.py
@@ -1,4 +1,4 @@
-import botocore
+import botocore.config
 
 
 class Config(object):
@@ -41,7 +41,24 @@ class Production(Config):
     }
 
 
+class Test(Config):
+    TESTING = True
+    PRIVATE_CAS = {
+        "vpn": {
+            "ca_id": "1",
+            "revocation_bucket": "test_vpn_bucket",
+            "account_id": "1234"
+        },
+        "tls": {
+            "ca_id": "2",
+            "revocation_bucket": "test_tls_bucket",
+            "account_id": "5678"
+        }
+    }
+
+
 configs = {
+    'test': Test,
     'development': Development,
     'staging': Staging,
     'production': Production,

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,3 @@
+[pytest]
+env =
+    NOTIFY_ENVIRONMENT=test

--- a/requirements_for_test.txt
+++ b/requirements_for_test.txt
@@ -5,3 +5,4 @@ flake8-bugbear==20.11.1
 moto[s3]==1.3.16
 pytest==6.2.1
 pytest-env==0.6.2
+pytest-mock==3.5.1

--- a/requirements_for_test.txt
+++ b/requirements_for_test.txt
@@ -2,5 +2,6 @@
 flake8==3.8.4
 flake8-print==4.0.0
 flake8-bugbear==20.11.1
+moto[s3]==1.3.16
 pytest==6.2.1
 pytest-env==0.6.2

--- a/requirements_for_test.txt
+++ b/requirements_for_test.txt
@@ -2,3 +2,5 @@
 flake8==3.8.4
 flake8-print==4.0.0
 flake8-bugbear==20.11.1
+pytest==6.2.1
+pytest-env==0.6.2

--- a/run_tests.sh
+++ b/run_tests.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+#
+# Run project tests
+
+set -o pipefail
+
+function display_result {
+  RESULT=$1
+  EXIT_STATUS=$2
+  TEST=$3
+
+  if [ $RESULT -ne 0 ]; then
+    echo -e "\033[31m$TEST failed\033[0m"
+    exit $EXIT_STATUS
+  else
+    echo -e "\033[32m$TEST passed\033[0m"
+  fi
+}
+
+flake8 .
+display_result $? 1 "Code style check"
+
+pytest -v
+display_result $? 2 "Unit tests"

--- a/test_main.py
+++ b/test_main.py
@@ -1,5 +1,7 @@
+import boto3
 import pytest
-from flask import url_for
+from flask import current_app, url_for
+from moto import mock_s3
 
 from main import create_app
 
@@ -25,3 +27,46 @@ def test_healthcheck(client):
     response = client.get(url_for('main.healthcheck'))
     assert response.status_code == 200
     assert response.data.decode('utf-8') == 'ok'
+
+
+def test_get_crl_returns_404_if_ca_name_is_unknown(client):
+    response = client.get(url_for('main.crl', ca_name='bad_name'))
+    assert response.status_code == 404
+
+
+@mock_s3
+@pytest.mark.parametrize('ca_name', ['vpn', 'tls'])
+def test_get_crl_returns_500_if_there_is_an_s3_error(client, ca_name):
+    ca = current_app.config['PRIVATE_CAS'][ca_name]
+
+    # Create the correct bucket, but leave it empty so that a
+    # botocore.exceptions.ClientError is raised when trying to get an object from it
+    conn = boto3.resource('s3', region_name=current_app.config['AWS_REGION'])
+    conn.create_bucket(
+        Bucket=ca['revocation_bucket'],
+        CreateBucketConfiguration={'LocationConstraint': current_app.config['AWS_REGION']}
+    )
+
+    response = client.get(url_for('main.crl', ca_name=ca_name))
+    assert response.status_code == 500
+
+
+@mock_s3
+@pytest.mark.parametrize('ca_name', ['vpn', 'tls'])
+def test_get_crl_returns_the_crl(client, ca_name):
+    ca = current_app.config['PRIVATE_CAS'][ca_name]
+    bucket_name = ca['revocation_bucket']
+    filename = f"crl/{ca['ca_id']}.crl"
+
+    conn = boto3.resource('s3', region_name=current_app.config['AWS_REGION'])
+    conn.create_bucket(
+        Bucket=bucket_name,
+        CreateBucketConfiguration={'LocationConstraint': current_app.config['AWS_REGION']}
+    )
+    s3 = boto3.client('s3', region_name=current_app.config['AWS_REGION'])
+    s3.put_object(Bucket=bucket_name, Key=filename, Body=b'This is a crl')
+
+    response = client.get(url_for('main.crl', ca_name=ca_name))
+    assert response.status_code == 200
+    assert response.data.decode('utf-8') == 'This is a crl'
+    assert response.mimetype == 'application/pkix-crl'

--- a/test_main.py
+++ b/test_main.py
@@ -1,0 +1,27 @@
+import pytest
+from flask import url_for
+
+from main import create_app
+
+
+@pytest.fixture(scope='session')
+def app():
+    app = create_app()
+    ctx = app.app_context()
+    ctx.push()
+
+    yield app
+
+    ctx.pop()
+
+
+@pytest.fixture
+def client(app):
+    with app.test_request_context(), app.test_client() as client:
+        yield client
+
+
+def test_healthcheck(client):
+    response = client.get(url_for('main.healthcheck'))
+    assert response.status_code == 200
+    assert response.data.decode('utf-8') == 'ok'


### PR DESCRIPTION
#### Set up the app with a test environment
We need to test this app, so this adds a test config class and changes the app to use the application factory pattern so that we can reuse the code in `main.py` more easily for the test Flask app.

This also sets up a single blueprint, main. Without this, all of the routes would need to be defined inside the `create_app` function, so the blueprint makes things easier to read.

#### Add tests for all the endpoints
Unfortunately moto does not support support acm-pca, which means that the tests for the sign_certificate endpoint end up mocking quite a lot.

#### Add unit tests to the test command in Makefile
This also adds a script to run the tests, copying the pattern that we use for other apps.