### PR TITLE
Protect sign_certificate endpoint using basic auth

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,12 +15,20 @@ We need to let the mobile networks have access to our CRLs. The CRLs are publica
 
 ## Set up and run locally
 
-To run this app locally, you need to make sure it has permissions to talk to the AWS Certificate Manager service. For local development we suggest you use the cell broadcast staging AWS account for this as shown in this example. 
+To run this app locally, you need to make sure it has permissions to talk to the AWS Certificate Manager service. For local development we suggest you use the cell broadcast staging AWS account for this as shown in this example.
 
 ```
 pip install -r requirements_for_test.txt
 export FLASK_APP=main.py
 export NOTIFY_ENVIRONMENT=development
+export EE_USERNAME=ee
+export EE_PASSWORD=ee_password
+export O2_USERNAME=o2
+export O2_PASSWORD=o2_password
+export VODAFONE_USERNAME=vodafone
+export VODAFONE_PASSWORD=vodafone_password
+export THREE_USERNAME=three
+export THREE_PASSWORD=three_password
 gds aws cell-broadcast-staging-admin -- flask run
 ```
 

--- a/config.py
+++ b/config.py
@@ -1,9 +1,27 @@
+import os
+
 import botocore.config
 
 
 class Config(object):
     AWS_REGION = "eu-west-2"
     AWS_CONFIG = botocore.config.Config(region_name=AWS_REGION)
+
+    EE_USERNAME = os.environ['EE_USERNAME']
+    EE_PASSWORD = os.environ['EE_PASSWORD']
+    O2_USERNAME = os.environ['O2_USERNAME']
+    O2_PASSWORD = os.environ['O2_PASSWORD']
+    VODAFONE_USERNAME = os.environ['VODAFONE_USERNAME']
+    VODAFONE_PASSWORD = os.environ['VODAFONE_PASSWORD']
+    THREE_USERNAME = os.environ['THREE_USERNAME']
+    THREE_PASSWORD = os.environ['THREE_PASSWORD']
+
+    CREDENTIALS = {
+        EE_USERNAME: EE_PASSWORD,
+        O2_USERNAME: O2_PASSWORD,
+        VODAFONE_USERNAME: VODAFONE_PASSWORD,
+        THREE_USERNAME: THREE_PASSWORD,
+    }
 
 
 class Staging(Config):

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,3 +1,11 @@
 [pytest]
 env =
     NOTIFY_ENVIRONMENT=test
+    EE_USERNAME=ee
+    EE_PASSWORD=ee_password
+    O2_USERNAME=o2
+    O2_PASSWORD=o2_password
+    VODAFONE_USERNAME=vodafone
+    VODAFONE_PASSWORD=vodafone_password
+    THREE_USERNAME=three
+    THREE_PASSWORD=three_password

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 Flask==1.1.2
+Flask-HTTPAuth==4.2.0
 boto3==1.16.38
 gunicorn==20.0.4


### PR DESCRIPTION
We want to protect the sign_certificate endpoint using basic
authentication. Each MNO will have a username and password.

In a later PR we can then use the basic auth username to check that MNOs
can only issue a CSR for one of their own certificates.