### PR TITLE
Only include files needed in our dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ FROM python:3.8.7-alpine3.12
 COPY requirements.txt /
 RUN pip install -r /requirements.txt
 
-COPY . /app
+COPY config.py main.py run.sh ./app/
 WORKDIR /app
 
 ENTRYPOINT ["./run.sh"]


### PR DESCRIPTION
Keeps things simple and won't clutter up the dockerfile.

Question. Is this a positive change? It feels intuitively good to only put things in the dockerfile that it actually needs to run the app but is this actually worth doing or shall I close this?