### PR TITLE
Send gunicorn logs to stdout

### DIFF
--- a/run.sh
+++ b/run.sh
@@ -1,2 +1,2 @@
 #!/bin/sh
-gunicorn main:app -w 2 --threads 2 -b 0.0.0.0:${PORT}
+gunicorn main:app -w 2 --threads 2 --access-logfile - -b 0.0.0.0:${PORT}


### PR DESCRIPTION
We want some basic access logs to appear in CloudWatch. Gunicorn disables access logs by default.

https://docs.gunicorn.org/en/stable/settings.html#accesslog