### PR TITLE
Create dependabot.yml

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,13 @@
+# Please see the documentation for all configuration options:
+# https://help.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
+
+version: 2
+updates:
+  - package-ecosystem: "pip"
+    directory: "/" #
+    schedule:
+      interval: "daily"
+  - package-ecosystem: "docker"
+    directory: "/"
+    schedule:
+      interval: "daily"


### PR DESCRIPTION
### Context
We have already enabled Dependabot dependency checks but they don't appear to be particularly regular.

### What does this do?
This PR explicitly configures the dependencies and frequency we require Dependabot to monitor for updates.

### How to test

To test this is enabled (once merged). On this repo's homepage click `Insights -> Dependency graph ->Dependabot tab`
