### PR TITLE
Update Cryptography to 3.4.7 with Rust build dependency

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,16 +1,22 @@
-FROM python:3.8.7-alpine3.12
+FROM python:3.8.7-alpine3.12 AS builder
 
 RUN apk add --no-cache \
         gcc \
         musl-dev \
         python3-dev \
         libffi-dev \
-        openssl-dev
+        openssl-dev \
+        cargo
 
 COPY requirements.txt /
-RUN pip install -r /requirements.txt
+RUN pip install --user -r /requirements.txt
 
+FROM python:3.8.7-alpine3.12
+
+COPY --from=builder /root/.local /root/.local
 COPY config.py main.py run.sh ./app/
 WORKDIR /app
+
+ENV PATH=/root/.local/bin:$PATH
 
 ENTRYPOINT ["./run.sh"]

--- a/env.dev
+++ b/env.dev
@@ -1,0 +1,13 @@
+NOTIFY_ENVIRONMENT=development
+EE_USERNAME=ee
+EE_PASSWORD=ee_password
+EE_COMMON_NAMES="[\"ee-allowed-common-name\"]"
+O2_USERNAME=o2
+O2_PASSWORD=o2_password
+O2_COMMON_NAMES="[\"o2-allowed-common-name\"]"
+VODAFONE_USERNAME=vodafone
+VODAFONE_PASSWORD=vodafone_password
+VODAFONE_COMMON_NAMES="[\"vodafone-allowed-common-name\"]"
+THREE_USERNAME=three
+THREE_PASSWORD=three_password
+THREE_COMMON_NAMES="[\"three-allowed-common-name\"]"

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 Flask==1.1.2
 Flask-HTTPAuth==4.2.0
 boto3==1.16.38
-cryptography==3.3.2
+cryptography==3.4.7
 gunicorn==20.0.4


### PR DESCRIPTION
### Context

Dependabot updated the Cryptography Python lib to 3.4.7 in #20, however the build fails because it now requires Rust as a build dependency since 3.4.0.

See Changelog: https://github.com/pyca/cryptography/blob/main/CHANGELOG.rst#34---2021-02-07

We use Alpine Linux as the container OS which does not support the anylinux prebuilt wheels, so we need to build from source requiring Rust/Cargo to be installed at build time.

See: https://cryptography.io/en/latest/installation/#alpine

### Multi stage Docker build

Because we need to install various packages at build time in order to produce the artefacts for use at runtime, we can use [Docker multistage builds](https://docs.docker.com/develop/develop-images/multistage-build/). The final pushed image only contains what is needed to run the final application resulting in a smaller, leaner image without extra software installed.

See GDS Way Dockerfile guidance for more information: https://gds-way.cloudapps.digital/manuals/programming-languages/docker.html#using-multi-stage-builds

### Environment file

I have added an environment file containing all the environment vars required to run the app locally. This can be passed to the running container using the `--env-file` option. See testing examples below. 

### Testing

To build the Docker image locally run:

`docker build -t notify/certificatemanagement:latest .`

To run the container on local port 8080 run:

`docker run -it -e "PORT=8080" --env-file ./env.dev -p 8080:8080 notify/certificatemanagement:latest`
